### PR TITLE
Added support for minimized strings

### DIFF
--- a/message-accumulator.js
+++ b/message-accumulator.js
@@ -20,6 +20,10 @@
 
 import Node from 'ilib-tree-node';
 
+function clone(obj) {
+    return Object.assign({}, obj);
+}
+
 /**
  * MessageAccumulator.js - accumulate a translatable message as a string
  */
@@ -218,15 +222,15 @@ export default class MessageAccumulator {
         while (changed && this.root.children && this.root.children.length) {
             changed = false;
             var subroot = this.root;
-            while (subroot.children && subroot.children.length === 1) {
-                value = (subroot.extra && subroot.extra.clone()) || {};
+            while (subroot.children && subroot.children.length === 1 && subroot.children[0].type !== "text") {
+                subroot = subroot.children[0];
+                value = (subroot.extra && clone(subroot.extra)) || {};
                 value.use = "start";
                 this.prefixes.push(value);
-                value = (subroot.extra && subroot.extra.clone()) || {};
+                value = (subroot.extra && clone(subroot.extra)) || {};
                 value.use = "end";
                 this.suffixes = [value].concat(this.suffixes);
 
-                subroot = subroot.children[0];
                 changed = true;
             }
 
@@ -237,7 +241,7 @@ export default class MessageAccumulator {
             while (i < children.length && children[i] && this._isEmpty(children[i])) {
                 i++;
                 if (children[i].extra) {
-                    value = children[i].extra.clone();
+                    value = clone(children[i].extra);
                     value.use = "start";
                 } else {
                     value = children[i].value;
@@ -253,7 +257,7 @@ export default class MessageAccumulator {
             while (i > 0 && children[i] && this._isEmpty(children[i])) {
                 i--;
                 if (children[i].extra) {
-                    value = children[i].extra.clone();
+                    value = clone(children[i].extra);
                     value.use = "end";
                 } else {
                     value = children[i].value;
@@ -262,7 +266,29 @@ export default class MessageAccumulator {
                 changed = true;
             }
 
+            // now strip off the leading and trailing whitespace
+            if (children.length && children[0].type === "text") {
+                var re = /^\s+/;
+                var match = re.exec(children[0].value);
+                if (match) {
+                    children[0].value = children[0].value.substring(match[0].length);
+                    this.prefixes.push(match[0]);
+                    changed = true;
+                }
+            }
+            var last = children.length-1;
+            if (children.length && children[last].type === "text") {
+                var re = /\s+$/;
+                var match = re.exec(children[last].value);
+                if (match) {
+                    children[last].value = children[last].value.substring(0, children[last].length - match[0].length);
+                    this.suffixes = [match[0]].concat(this.suffixes);
+                    changed = true;
+                }
+            }
+
             this.root.children = i < children.length - 1 ? children.slice(0, i+1) : children;
+            // then do it all again until nothing changes!
         }
 
         // now walk the tree again and renumber any components so that we don't start at some number greater
@@ -343,7 +369,7 @@ export default class MessageAccumulator {
      */
     getSuffix() {
         this._minimize();
-        return this.prefixes || [];
+        return this.suffixes || [];
     }
 
     /**

--- a/message-accumulator.js
+++ b/message-accumulator.js
@@ -245,9 +245,11 @@ export default class MessageAccumulator {
             return node.value;
         }
 
+        // keep stripping off parts until we haven't changed anything, or we have stripped off everything
         while (changed && this.root.children && this.root.children.length) {
             changed = false;
             var subroot = this.root;
+            // check for "outer" components -- components that surround localizable text without adding anything to it
             while (subroot.children && subroot.children.length === 1 && subroot.children[0].type !== "text") {
                 subroot = subroot.children[0];
                 value = clone(subroot.extra);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "message-accumulator",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "main": "./message-accumulator-es5.js",
     "main-es6": "./message-accumulator.js",
     "description": "A package to accumulate localizable snippets of HTML or JSX text and to compose and decompose them to/from localizable strings",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "debug": "npm run build ; node --inspect-brk test/testSuite.js"
     },
     "dependencies": {
-        "ilib-tree-node": "^1.0.0"
+        "ilib-tree-node": "^1.1.0"
     },
     "devDependencies": {
         "acorn": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -54,20 +54,18 @@
         "ilib-tree-node": "^1.1.0"
     },
     "devDependencies": {
-        "acorn": "^6.0.2",
-        "acorn-jsx": "^5.0.0",
         "babel-core": "^6.26.0",
         "babel-preset-env": "*",
         "babel-register": "^6.26.0",
         "babel-runtime": "^6.26.0",
         "grunt": "^1.0.3",
+        "grunt-babel": "^7.0.0",
         "grunt-contrib-clean": "^2.0.0",
         "grunt-contrib-jshint": "^2.0.0",
         "grunt-contrib-nodeunit": "^2.0.0",
         "grunt-contrib-uglify": "^4.0.0",
-        "grunt-babel": "^7.0.0",
         "load-grunt-tasks": "^4.0.0",
-        "promise": "8.0.1",
-        "nodeunit": "0.11.0"
+        "nodeunit": "0.11.0",
+        "promise": "8.0.1"
     }
 }

--- a/test/testmessageacc.js
+++ b/test/testmessageacc.js
@@ -1165,7 +1165,7 @@ module.exports.testAccumulator = {
         test.ok(ma);
 
         test.ok(ma.root.children);
-        test.equal(ma.root.children.length, 4);
+        test.equal(ma.root.children.length, 3);
 
         test.equal(ma.getString(), "   This is a test of the <c0>decomposition</c0> system.   ");
         test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
@@ -1270,7 +1270,7 @@ module.exports.testAccumulator = {
         test.ok(ma);
 
         test.ok(ma.root.children);
-        test.equal(ma.root.children.length, 4);
+        test.equal(ma.root.children.length, 5);
 
         test.equal(ma.getString(), "<c0></c0>This is a test of the <c1>decomposition</c1> system.<c2></c2>");
         test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
@@ -1285,7 +1285,7 @@ module.exports.testAccumulator = {
         test.ok(ma);
 
         test.ok(ma.root.children);
-        test.equal(ma.root.children.length, 4);
+        test.equal(ma.root.children.length, 5);
 
         test.equal(ma.getString(), "<c0>\n</c0>This is a test of the <c1>decomposition</c1> system.<c2>    </c2>");
         test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
@@ -1300,7 +1300,7 @@ module.exports.testAccumulator = {
         test.ok(ma);
 
         test.ok(ma.root.children);
-        test.equal(ma.root.children.length, 4);
+        test.equal(ma.root.children.length, 5);
 
         test.equal(ma.getString(), "<c0>\n  <c1>\n  </c1>\n</c0>This is a test of the <c2>decomposition</c2> system.<c3>  <c4> </c4>  </c3>");
         test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
@@ -1315,7 +1315,7 @@ module.exports.testAccumulator = {
         test.ok(ma);
 
         test.ok(ma.root.children);
-        test.equal(ma.root.children.length, 4);
+        test.equal(ma.root.children.length, 1);
 
         test.equal(ma.getString(), "<c0><c1></c1>This is a test of the <c2>decomposition</c2> system.</c0>");
         test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
@@ -1330,7 +1330,7 @@ module.exports.testAccumulator = {
         test.ok(ma);
 
         test.ok(ma.root.children);
-        test.equal(ma.root.children.length, 4);
+        test.equal(ma.root.children.length, 1);
 
         test.equal(ma.getString(), "<c0>This is a test of the <c1>decomposition</c1> system.<c2></c2></c0>");
         test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
@@ -1339,13 +1339,13 @@ module.exports.testAccumulator = {
     },
 
     testMessageAccumulatorMinimizeVeryComplexWithMultipleLevels: function(test) {
-        test.expect(4);
+        test.expect(5);
 
         let ma = MessageAccumulator.create("<c0><c1>  \t </c1><c2>\n<c3>\n<c4></c4></c3>\n  This is a test of the <c5>decomposition</c5> system.   <c6>\n</c6></c2></c0>");
         test.ok(ma);
 
         test.ok(ma.root.children);
-        test.equal(ma.root.children.length, 4);
+        test.equal(ma.root.children.length, 1);
 
         test.equal(ma.getString(), "<c0><c1>  \t </c1><c2>\n<c3>\n<c4></c4></c3>\n  This is a test of the <c5>decomposition</c5> system.   <c6>\n</c6></c2></c0>");
         test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
@@ -1354,7 +1354,7 @@ module.exports.testAccumulator = {
     },
 
     testMessageAccumulatorMinimizeVeryComplexPrefix: function(test) {
-        test.expect(4);
+        test.expect(19);
 
         let source = new MessageAccumulator();
         test.ok(source);
@@ -1407,7 +1407,7 @@ module.exports.testAccumulator = {
     },
 
     testMessageAccumulatorMinimizeVeryComplexSuffix: function(test) {
-        test.expect(4);
+        test.expect(13);
 
         let source = new MessageAccumulator();
         test.ok(source);

--- a/test/testmessageacc.js
+++ b/test/testmessageacc.js
@@ -76,7 +76,7 @@ module.exports.testAccumulator = {
     testMessageAccumulatorFromStringWithEmptyComponent: function(test) {
         test.expect(4);
 
-        let ma = MessageAccumulator.create("<c0></c0>");
+        let ma = MessageAccumulator.create("<c0/>");
         test.ok(ma);
 
         test.ok(ma.root.children);
@@ -534,7 +534,7 @@ module.exports.testAccumulator = {
 
         test.equal(ma.root.children.length, 3);
 
-        test.equal(ma.getString(), "This is a test of the <c0></c0> emergency message system.");
+        test.equal(ma.getString(), "This is a test of the <c0/> emergency message system.");
 
         test.done();
     },
@@ -1176,13 +1176,13 @@ module.exports.testAccumulator = {
     testMessageAccumulatorMinimizePrefixComponents: function(test) {
         test.expect(5);
 
-        let ma = MessageAccumulator.create("<c0></c0>This is a test of the <c1>decomposition</c1> system.");
+        let ma = MessageAccumulator.create("<c0/>This is a test of the <c1>decomposition</c1> system.");
         test.ok(ma);
 
         test.ok(ma.root.children);
         test.equal(ma.root.children.length, 4);
 
-        test.equal(ma.getString(), "<c0></c0>This is a test of the <c1>decomposition</c1> system.");
+        test.equal(ma.getString(), "<c0/>This is a test of the <c1>decomposition</c1> system.");
         test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
 
         test.done();
@@ -1221,13 +1221,13 @@ module.exports.testAccumulator = {
     testMessageAccumulatorMinimizeSuffixComponents: function(test) {
         test.expect(5);
 
-        let ma = MessageAccumulator.create("This is a test of the <c0>decomposition</c0> system.<c1></c1>");
+        let ma = MessageAccumulator.create("This is a test of the <c0>decomposition</c0> system.<c1/>");
         test.ok(ma);
 
         test.ok(ma.root.children);
         test.equal(ma.root.children.length, 4);
 
-        test.equal(ma.getString(), "This is a test of the <c0>decomposition</c0> system.<c1></c1>");
+        test.equal(ma.getString(), "This is a test of the <c0>decomposition</c0> system.<c1/>");
         test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
 
         test.done();
@@ -1266,13 +1266,13 @@ module.exports.testAccumulator = {
     testMessageAccumulatorMinimizePrefixAndSuffixComponents: function(test) {
         test.expect(5);
 
-        let ma = MessageAccumulator.create("<c0></c0>This is a test of the <c1>decomposition</c1> system.<c2></c2>");
+        let ma = MessageAccumulator.create("<c0/>This is a test of the <c1>decomposition</c1> system.<c2/>");
         test.ok(ma);
 
         test.ok(ma.root.children);
         test.equal(ma.root.children.length, 5);
 
-        test.equal(ma.getString(), "<c0></c0>This is a test of the <c1>decomposition</c1> system.<c2></c2>");
+        test.equal(ma.getString(), "<c0/>This is a test of the <c1>decomposition</c1> system.<c2/>");
         test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
 
         test.done();
@@ -1311,13 +1311,13 @@ module.exports.testAccumulator = {
     testMessageAccumulatorMinimizePrefixAndOuterComponents: function(test) {
         test.expect(5);
 
-        let ma = MessageAccumulator.create("<c0><c1></c1>This is a test of the <c2>decomposition</c2> system.</c0>");
+        let ma = MessageAccumulator.create("<c0><c1/>This is a test of the <c2>decomposition</c2> system.</c0>");
         test.ok(ma);
 
         test.ok(ma.root.children);
         test.equal(ma.root.children.length, 1);
 
-        test.equal(ma.getString(), "<c0><c1></c1>This is a test of the <c2>decomposition</c2> system.</c0>");
+        test.equal(ma.getString(), "<c0><c1/>This is a test of the <c2>decomposition</c2> system.</c0>");
         test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
 
         test.done();
@@ -1326,13 +1326,13 @@ module.exports.testAccumulator = {
     testMessageAccumulatorMinimizeSuffixAndOuterComponents: function(test) {
         test.expect(5);
 
-        let ma = MessageAccumulator.create("<c0>This is a test of the <c1>decomposition</c1> system.<c2></c2></c0>");
+        let ma = MessageAccumulator.create("<c0>This is a test of the <c1>decomposition</c1> system.<c2/></c0>");
         test.ok(ma);
 
         test.ok(ma.root.children);
         test.equal(ma.root.children.length, 1);
 
-        test.equal(ma.getString(), "<c0>This is a test of the <c1>decomposition</c1> system.<c2></c2></c0>");
+        test.equal(ma.getString(), "<c0>This is a test of the <c1>decomposition</c1> system.<c2/></c0>");
         test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
 
         test.done();
@@ -1341,13 +1341,13 @@ module.exports.testAccumulator = {
     testMessageAccumulatorMinimizeVeryComplexWithMultipleLevels: function(test) {
         test.expect(5);
 
-        let ma = MessageAccumulator.create("<c0><c1>  \t </c1><c2>\n<c3>\n<c4></c4></c3>\n  This is a test of the <c5>decomposition</c5> system.   <c6>\n</c6></c2></c0>");
+        let ma = MessageAccumulator.create("<c0><c1>  \t </c1><c2>\n<c3>\n<c4/></c3>\n  This is a test of the <c5>decomposition</c5> system.   <c6>\n</c6></c2></c0>");
         test.ok(ma);
 
         test.ok(ma.root.children);
         test.equal(ma.root.children.length, 1);
 
-        test.equal(ma.getString(), "<c0><c1>  \t </c1><c2>\n<c3>\n<c4></c4></c3>\n  This is a test of the <c5>decomposition</c5> system.   <c6>\n</c6></c2></c0>");
+        test.equal(ma.getString(), "<c0><c1>  \t </c1><c2>\n<c3>\n<c4/></c3>\n  This is a test of the <c5>decomposition</c5> system.   <c6>\n</c6></c2></c0>");
         test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
 
         test.done();
@@ -1384,7 +1384,7 @@ module.exports.testAccumulator = {
         test.ok(source.root.children);
         test.equal(source.root.children.length, 1);
 
-        test.equal(source.getString(), "<c0><c1>  \t </c1><c2>\n<c3>\n<c4></c4></c3>\n  This is a test of the <c5>decomposition</c5> system.   <c6>\n</c6></c2></c0>");
+        test.equal(source.getString(), "<c0><c1>  \t </c1><c2>\n<c3>\n<c4/></c3>\n  This is a test of the <c5>decomposition</c5> system.   <c6>\n</c6></c2></c0>");
         test.equal(source.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
 
         var prefix = source.getPrefix();
@@ -1436,7 +1436,7 @@ module.exports.testAccumulator = {
         test.ok(source.root.children);
         test.equal(source.root.children.length, 1);
 
-        test.equal(source.getString(), "<c0><c1>  \t </c1><c2>\n<c3>\n<c4></c4></c3>\n  This is a test of the <c5>decomposition</c5> system.   <c6>\n</c6></c2></c0>");
+        test.equal(source.getString(), "<c0><c1>  \t </c1><c2>\n<c3>\n<c4/></c3>\n  This is a test of the <c5>decomposition</c5> system.   <c6>\n</c6></c2></c0>");
         test.equal(source.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
 
         var prefix = source.getSuffix();
@@ -1456,7 +1456,7 @@ module.exports.testAccumulator = {
     testMessageAccumulatorMinimizeMappingStillCorrect: function(test) {
         test.expect(7);
 
-        let ma = MessageAccumulator.create("<c0>This is a test of the <c1>decomposition</c1> system.<c2></c2></c0>");
+        let ma = MessageAccumulator.create("<c0>This is a test of the <c1>decomposition</c1> system.<c2/></c0>");
         test.ok(ma);
         let source = new MessageAccumulator();
         test.ok(source);
@@ -1489,9 +1489,8 @@ module.exports.testAccumulator = {
         test.done();
     },
 
-    /*
     testMessageAccumulatorParseSelfClosingComponent: function(test) {
-        test.expect(5);
+        test.expect(4);
 
         let ma = MessageAccumulator.create("This is a test of the <c0/> decomposition system.");
         test.ok(ma);
@@ -1512,6 +1511,54 @@ module.exports.testAccumulator = {
 
         test.done();
     },
-    */
+
+    testMessageAccumulatorCreateWithSource: function(test) {
+        test.expect(5);
+
+        let source = new MessageAccumulator();
+        test.ok(source);
+
+        source.addText("This is a test of the ");
+        source.push({text: '<img src="http://www.example.com/foo.jpg">'});
+        source.pop();
+        source.addText(" decomposition system.");
+
+        // The translation has the components swapped from the English
+        let ma = MessageAccumulator.create("Dies ist einen Test des <c0/> Zersetzungssystems.", source);
+        test.ok(ma);
+
+        test.ok(ma.root.children);
+        test.equal(ma.root.children.length, 3);
+
+        test.contains(ma.root, {
+            children: [
+                {value: "Dies ist einen Test des "},
+                {
+                    children: [],
+                    index: 0,
+                    extra: {text: '<img src="http://www.example.com/foo.jpg">'}
+                },
+                {value: " Zersetzungssystems."}
+            ]
+        });
+
+        test.done();
+    },
+
+    testMessageAccumulatorGetStringSelfClosing: function(test) {
+        test.expect(2);
+
+        let source = new MessageAccumulator();
+        test.ok(source);
+
+        source.addText("This is a test of the ");
+        source.push({text: '<img src="http://www.example.com/foo.jpg">'});
+        source.pop();
+        source.addText(" decomposition system.");
+
+        test.equal(source.getString(), "This is a test of the <c0/> decomposition system.");
+        
+        test.done();
+    },
 
 };

--- a/test/testmessageacc.js
+++ b/test/testmessageacc.js
@@ -881,4 +881,75 @@ module.exports.testAccumulator = {
         test.done();
     },
 
+    testMessageAccumulatorCullOuterComponent: function(test) {
+        test.expect(7);
+
+        let source = new MessageAccumulator();
+        test.ok(source);
+
+        source.push({name: "a"});
+        source.addText("You give ");
+        source.push({name: "b"});
+        source.addText("the ball");
+        source.pop();
+        source.addText(" a big ");
+        source.push({name: "i"});
+        source.addText("kick");
+        source.pop();
+        source.addText(" towards the goal.");
+        source.pop();
+
+        test.equal(source.getString(), "<c0>You give <c1>the ball</c1> a big <c2>kick</c2> towards the goal.</c0>");
+        test.equal(source.getCulledString(), "You give <c1>the ball</c1> a big <c2>kick</c2> towards the goal.");
+    },
+
+    testMessageAccumulatorCullOuterComponents: function(test) {
+        test.expect(7);
+
+        let source = new MessageAccumulator();
+        test.ok(source);
+
+        source.push({name: "a"});
+        source.push({name: "x"});
+        source.push({name: "y"});
+        source.addText("You give ");
+        source.push({name: "b"});
+        source.addText("the ball");
+        source.pop();
+        source.addText(" a big ");
+        source.push({name: "i"});
+        source.addText("kick");
+        source.pop();
+        source.addText(" towards the goal.");
+        source.pop();
+        source.pop();
+        source.pop();
+
+        test.equal(source.getString(), "<c0><c1><c2>You give <c3>the ball</c3> a big <c4>kick</c4> towards the goal.</c2></c1></c0>");
+        test.equal(source.getCulledString(), "You give <c3>the ball</c3> a big <c4>kick</c4> towards the goal.");
+    },
+
+    testMessageAccumulatorDontCullNonOuterComponents: function(test) {
+        test.expect(7);
+
+        let source = new MessageAccumulator();
+        test.ok(source);
+
+        source.push({name: "a"});
+        source.addText("You give ");
+        source.push({name: "b"});
+        source.addText("the ball");
+        source.pop();
+        source.addText(" a big ");
+        source.push({name: "i"});
+        source.addText("kick");
+        source.pop();
+        source.addText(" towards the goal.");
+        source.pop();
+        source.addText(" After you score, you celebrate.");
+
+        test.equal(source.getString(), "<c0>You give <c1>the ball</c1> a big <c2>kick</c2> towards the goal.</c0> After you score, you celebrate.");
+        test.equal(source.getCulledString(), "<c0>You give <c1>the ball</c1> a big <c2>kick</c2> towards the goal.</c0> After you score, you celebrate.");
+    },
+
 };

--- a/test/testmessageacc.js
+++ b/test/testmessageacc.js
@@ -881,7 +881,7 @@ module.exports.testAccumulator = {
         test.done();
     },
 
-    testMessageAccumulatorCullOuterComponent: function(test) {
+    testMessageAccumulatorMinimizeOuterComponents: function(test) {
         test.expect(3);
 
         let source = new MessageAccumulator();
@@ -900,12 +900,68 @@ module.exports.testAccumulator = {
         source.pop();
 
         test.equal(source.getString(), "<c0>You give <c1>the ball</c1> a big <c2>kick</c2> towards the goal.</c0>");
-        test.equal(source.getCulledString(), "You give <c1>the ball</c1> a big <c2>kick</c2> towards the goal.");
+        test.equal(source.getMinimalString(), "You give <c0>the ball</c0> a big <c1>kick</c1> towards the goal.");
 
         test.done();
     },
 
-    testMessageAccumulatorCullOuterComponents: function(test) {
+    testMessageAccumulatorGetPrefix: function(test) {
+        test.expect(6);
+
+        let source = new MessageAccumulator();
+        test.ok(source);
+
+        source.push({name: "a"});
+        source.addText("You give ");
+        source.push({name: "b"});
+        source.addText("the ball");
+        source.pop();
+        source.addText(" a big ");
+        source.push({name: "i"});
+        source.addText("kick");
+        source.pop();
+        source.addText(" towards the goal.");
+        source.pop();
+
+        test.equal(source.getString(), "<c0>You give <c1>the ball</c1> a big <c2>kick</c2> towards the goal.</c0>");
+        test.equal(source.getMinimalString(), "You give <c0>the ball</c0> a big <c1>kick</c1> towards the goal.");
+        var prefix = source.getPrefix();
+        test.ok(prefix);
+        test.equal(prefix.length, 1);
+        test.deepEqual(prefix[0], {name: "a", use: "start"});
+
+        test.done();
+    },
+
+    testMessageAccumulatorGetSuffix: function(test) {
+        test.expect(6);
+
+        let source = new MessageAccumulator();
+        test.ok(source);
+
+        source.push({name: "a"});
+        source.addText("You give ");
+        source.push({name: "b"});
+        source.addText("the ball");
+        source.pop();
+        source.addText(" a big ");
+        source.push({name: "i"});
+        source.addText("kick");
+        source.pop();
+        source.addText(" towards the goal.");
+        source.pop();
+
+        test.equal(source.getString(), "<c0>You give <c1>the ball</c1> a big <c2>kick</c2> towards the goal.</c0>");
+        test.equal(source.getMinimalString(), "You give <c0>the ball</c0> a big <c1>kick</c1> towards the goal.");
+        var suffix = source.getSuffix();
+        test.ok(suffix);
+        test.equal(suffix.length, 1);
+        test.deepEqual(suffix[0], {name: "a", use: "end"});
+
+        test.done();
+    },
+
+    testMessageAccumulatorMinimizeMultipleOuterComponents: function(test) {
         test.expect(3);
 
         let source = new MessageAccumulator();
@@ -928,12 +984,82 @@ module.exports.testAccumulator = {
         source.pop();
 
         test.equal(source.getString(), "<c0><c1><c2>You give <c3>the ball</c3> a big <c4>kick</c4> towards the goal.</c2></c1></c0>");
-        test.equal(source.getCulledString(), "You give <c3>the ball</c3> a big <c4>kick</c4> towards the goal.");
+        test.equal(source.getMinimalString(), "You give <c0>the ball</c0> a big <c1>kick</c1> towards the goal.");
 
         test.done();
     },
 
-    testMessageAccumulatorDontCullNonOuterComponents: function(test) {
+    testMessageAccumulatorGetPrefixMultiple: function(test) {
+        test.expect(3);
+
+        let source = new MessageAccumulator();
+        test.ok(source);
+
+        source.push({name: "a"});
+        source.push({name: "x"});
+        source.push({name: "y"});
+        source.addText("You give ");
+        source.push({name: "b"});
+        source.addText("the ball");
+        source.pop();
+        source.addText(" a big ");
+        source.push({name: "i"});
+        source.addText("kick");
+        source.pop();
+        source.addText(" towards the goal.");
+        source.pop();
+        source.pop();
+        source.pop();
+
+        test.equal(source.getString(), "<c0><c1><c2>You give <c3>the ball</c3> a big <c4>kick</c4> towards the goal.</c2></c1></c0>");
+        test.equal(source.getMinimalString(), "You give <c0>the ball</c0> a big <c1>kick</c1> towards the goal.");
+
+        var prefix = source.getPrefix();
+        test.ok(prefix);
+        test.equal(prefix.length, 3);
+        test.deepEqual(prefix[0], {name: "a", use: "start"});
+        test.deepEqual(prefix[1], {name: "x", use: "start"});
+        test.deepEqual(prefix[2], {name: "y", use: "start"});
+
+        test.done();
+    },
+
+    testMessageAccumulatorGetSuffixMultiple: function(test) {
+        test.expect(3);
+
+        let source = new MessageAccumulator();
+        test.ok(source);
+
+        source.push({name: "a"});
+        source.push({name: "x"});
+        source.push({name: "y"});
+        source.addText("You give ");
+        source.push({name: "b"});
+        source.addText("the ball");
+        source.pop();
+        source.addText(" a big ");
+        source.push({name: "i"});
+        source.addText("kick");
+        source.pop();
+        source.addText(" towards the goal.");
+        source.pop();
+        source.pop();
+        source.pop();
+
+        test.equal(source.getString(), "<c0><c1><c2>You give <c3>the ball</c3> a big <c4>kick</c4> towards the goal.</c2></c1></c0>");
+        test.equal(source.getMinimalString(), "You give <c0>the ball</c0> a big <c1>kick</c1> towards the goal.");
+
+        var suffix = source.getSuffix();
+        test.ok(suffix);
+        test.equal(suffix.length, 3);
+        test.deepEqual(suffix[0], {name: "a", use: "end"});
+        test.deepEqual(suffix[1], {name: "x", use: "end"});
+        test.deepEqual(suffix[2], {name: "y", use: "end"});
+
+        test.done();
+    },
+
+    testMessageAccumulatorDontMinimizeNonOuterComponents: function(test) {
         test.expect(3);
 
         let source = new MessageAccumulator();
@@ -953,24 +1079,57 @@ module.exports.testAccumulator = {
         source.addText(" After you score, you celebrate.");
 
         test.equal(source.getString(), "<c0>You give <c1>the ball</c1> a big <c2>kick</c2> towards the goal.</c0> After you score, you celebrate.");
-        test.equal(source.getCulledString(), "<c0>You give <c1>the ball</c1> a big <c2>kick</c2> towards the goal.</c0> After you score, you celebrate.");
+        test.equal(source.getMinimalString(), "<c0>You give <c1>the ball</c1> a big <c2>kick</c2> towards the goal.</c0> After you score, you celebrate.");
 
         test.done();
     },
 
-    testMessageAccumulatorCullEmpty: function(test) {
+    testMessageAccumulatorDontMinimizeNonOuterComponentsNoPrefixOrSuffix: function(test) {
+        test.expect(3);
+
+        let source = new MessageAccumulator();
+        test.ok(source);
+
+        source.push({name: "a"});
+        source.addText("You give ");
+        source.push({name: "b"});
+        source.addText("the ball");
+        source.pop();
+        source.addText(" a big ");
+        source.push({name: "i"});
+        source.addText("kick");
+        source.pop();
+        source.addText(" towards the goal.");
+        source.pop();
+        source.addText(" After you score, you celebrate.");
+
+        test.equal(source.getString(), "<c0>You give <c1>the ball</c1> a big <c2>kick</c2> towards the goal.</c0> After you score, you celebrate.");
+        test.equal(source.getMinimalString(), "<c0>You give <c1>the ball</c1> a big <c2>kick</c2> towards the goal.</c0> After you score, you celebrate.");
+
+        var prefix = source.getPrefix();
+        test.ok(prefix);
+        test.equal(prefix.length, 0);
+
+        var suffix = source.getSuffix();
+        test.ok(suffix);
+        test.equal(suffix.length, 0);
+
+        test.done();
+    },
+
+    testMessageAccumulatorMinimizeEmpty: function(test) {
         test.expect(3);
 
         let source = new MessageAccumulator();
         test.ok(source);
 
         test.equal(source.getString(), "");
-        test.equal(source.getCulledString(), "");
+        test.equal(source.getMinimalString(), "");
 
         test.done();
     },
 
-    testMessageAccumulatorCullSimple: function(test) {
+    testMessageAccumulatorMinimizeSimple: function(test) {
         test.expect(3);
 
         let source = new MessageAccumulator();
@@ -979,12 +1138,12 @@ module.exports.testAccumulator = {
         source.addText("Test");
 
         test.equal(source.getString(), "Test");
-        test.equal(source.getCulledString(), "Test");
+        test.equal(source.getMinimalString(), "Test");
 
         test.done();
     },
 
-    testMessageAccumulatorCullUnbalanced: function(test) {
+    testMessageAccumulatorMinimizeUnbalanced: function(test) {
         test.expect(3);
 
         let source = new MessageAccumulator();
@@ -994,7 +1153,339 @@ module.exports.testAccumulator = {
         source.addText("Test");
 
         test.equal(source.getString(), "<c0>Test</c0>");
-        test.equal(source.getCulledString(), "Test");
+        test.equal(source.getMinimalString(), "Test");
+
+        test.done();
+    },
+
+    testMessageAccumulatorMinimizeWhitespace: function(test) {
+        test.expect(5);
+
+        let ma = MessageAccumulator.create("   This is a test of the <c0>decomposition</c0> system.   ");
+        test.ok(ma);
+
+        test.ok(ma.root.children);
+        test.equal(ma.root.children.length, 4);
+
+        test.equal(ma.getString(), "   This is a test of the <c0>decomposition</c0> system.   ");
+        test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
+
+        test.done();
+    },
+
+    testMessageAccumulatorMinimizePrefixComponents: function(test) {
+        test.expect(5);
+
+        let ma = MessageAccumulator.create("<c0></c0>This is a test of the <c1>decomposition</c1> system.");
+        test.ok(ma);
+
+        test.ok(ma.root.children);
+        test.equal(ma.root.children.length, 4);
+
+        test.equal(ma.getString(), "<c0></c0>This is a test of the <c1>decomposition</c1> system.");
+        test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
+
+        test.done();
+    },
+
+    testMessageAccumulatorMinimizePrefixComponentsWithSpace: function(test) {
+        test.expect(5);
+
+        let ma = MessageAccumulator.create("<c0>    </c0>This is a test of the <c1>decomposition</c1> system.");
+        test.ok(ma);
+
+        test.ok(ma.root.children);
+        test.equal(ma.root.children.length, 4);
+
+        test.equal(ma.getString(), "<c0>    </c0>This is a test of the <c1>decomposition</c1> system.");
+        test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
+
+        test.done();
+    },
+
+    testMessageAccumulatorMinimizePrefixComponentsWithSpaceAndSubcomponents: function(test) {
+        test.expect(5);
+
+        let ma = MessageAccumulator.create("<c0>\n  <c1>\n  </c1>\n</c0>This is a test of the <c2>decomposition</c2> system.");
+        test.ok(ma);
+
+        test.ok(ma.root.children);
+        test.equal(ma.root.children.length, 4);
+
+        test.equal(ma.getString(), "<c0>\n  <c1>\n  </c1>\n</c0>This is a test of the <c2>decomposition</c2> system.");
+        test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
+
+        test.done();
+    },
+
+    testMessageAccumulatorMinimizeSuffixComponents: function(test) {
+        test.expect(5);
+
+        let ma = MessageAccumulator.create("This is a test of the <c0>decomposition</c0> system.<c1></c1>");
+        test.ok(ma);
+
+        test.ok(ma.root.children);
+        test.equal(ma.root.children.length, 4);
+
+        test.equal(ma.getString(), "This is a test of the <c0>decomposition</c0> system.<c1></c1>");
+        test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
+
+        test.done();
+    },
+
+    testMessageAccumulatorMinimizeSuffixComponentsWithSpace: function(test) {
+        test.expect(5);
+
+        let ma = MessageAccumulator.create("This is a test of the <c0>decomposition</c0> system.<c1>    </c1>");
+        test.ok(ma);
+
+        test.ok(ma.root.children);
+        test.equal(ma.root.children.length, 4);
+
+        test.equal(ma.getString(), "This is a test of the <c0>decomposition</c0> system.<c1>    </c1>");
+        test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
+
+        test.done();
+    },
+
+    testMessageAccumulatorMinimizeSuffixComponentsWithSpaceAndSubcomponents: function(test) {
+        test.expect(5);
+
+        let ma = MessageAccumulator.create("This is a test of the <c0>decomposition</c0> system.<c1>\n  <c2>\n  </c2>\n</c1>");
+        test.ok(ma);
+
+        test.ok(ma.root.children);
+        test.equal(ma.root.children.length, 4);
+
+        test.equal(ma.getString(), "This is a test of the <c0>decomposition</c0> system.<c1>\n  <c2>\n  </c2>\n</c1>");
+        test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
+
+        test.done();
+    },
+
+    testMessageAccumulatorMinimizePrefixAndSuffixComponents: function(test) {
+        test.expect(5);
+
+        let ma = MessageAccumulator.create("<c0></c0>This is a test of the <c1>decomposition</c1> system.<c2></c2>");
+        test.ok(ma);
+
+        test.ok(ma.root.children);
+        test.equal(ma.root.children.length, 4);
+
+        test.equal(ma.getString(), "<c0></c0>This is a test of the <c1>decomposition</c1> system.<c2></c2>");
+        test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
+
+        test.done();
+    },
+
+    testMessageAccumulatorMinimizePrefixAndSuffixComponentsWithSpace: function(test) {
+        test.expect(5);
+
+        let ma = MessageAccumulator.create("<c0>\n</c0>This is a test of the <c1>decomposition</c1> system.<c2>    </c2>");
+        test.ok(ma);
+
+        test.ok(ma.root.children);
+        test.equal(ma.root.children.length, 4);
+
+        test.equal(ma.getString(), "<c0>\n</c0>This is a test of the <c1>decomposition</c1> system.<c2>    </c2>");
+        test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
+
+        test.done();
+    },
+
+    testMessageAccumulatorMinimizePrefixAndSuffixComponentsWithSpaceAndSubcomponents: function(test) {
+        test.expect(5);
+
+        let ma = MessageAccumulator.create("<c0>\n  <c1>\n  </c1>\n</c0>This is a test of the <c2>decomposition</c2> system.<c3>  <c4> </c4>  </c3>");
+        test.ok(ma);
+
+        test.ok(ma.root.children);
+        test.equal(ma.root.children.length, 4);
+
+        test.equal(ma.getString(), "<c0>\n  <c1>\n  </c1>\n</c0>This is a test of the <c2>decomposition</c2> system.<c3>  <c4> </c4>  </c3>");
+        test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
+
+        test.done();
+    },
+
+    testMessageAccumulatorMinimizePrefixAndOuterComponents: function(test) {
+        test.expect(5);
+
+        let ma = MessageAccumulator.create("<c0><c1></c1>This is a test of the <c2>decomposition</c2> system.</c0>");
+        test.ok(ma);
+
+        test.ok(ma.root.children);
+        test.equal(ma.root.children.length, 4);
+
+        test.equal(ma.getString(), "<c0><c1></c1>This is a test of the <c2>decomposition</c2> system.</c0>");
+        test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
+
+        test.done();
+    },
+
+    testMessageAccumulatorMinimizeSuffixAndOuterComponents: function(test) {
+        test.expect(5);
+
+        let ma = MessageAccumulator.create("<c0>This is a test of the <c1>decomposition</c1> system.<c2></c2></c0>");
+        test.ok(ma);
+
+        test.ok(ma.root.children);
+        test.equal(ma.root.children.length, 4);
+
+        test.equal(ma.getString(), "<c0>This is a test of the <c1>decomposition</c1> system.<c2></c2></c0>");
+        test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
+
+        test.done();
+    },
+
+    testMessageAccumulatorMinimizeVeryComplexWithMultipleLevels: function(test) {
+        test.expect(4);
+
+        let ma = MessageAccumulator.create("<c0><c1>  \t </c1><c2>\n<c3>\n<c4></c4></c3>\n  This is a test of the <c5>decomposition</c5> system.   <c6>\n</c6></c2></c0>");
+        test.ok(ma);
+
+        test.ok(ma.root.children);
+        test.equal(ma.root.children.length, 4);
+
+        test.equal(ma.getString(), "<c0><c1>  \t </c1><c2>\n<c3>\n<c4></c4></c3>\n  This is a test of the <c5>decomposition</c5> system.   <c6>\n</c6></c2></c0>");
+        test.equal(ma.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
+
+        test.done();
+    },
+
+    testMessageAccumulatorMinimizeVeryComplexPrefix: function(test) {
+        test.expect(4);
+
+        let source = new MessageAccumulator();
+        test.ok(source);
+
+        source.push({name: "a"});
+        source.push({name: "b"});
+        source.addText("  \t ");
+        source.pop();
+        source.push({name: "c"});
+        source.addText("\n");
+        source.push({name: "d"});
+        source.addText("\n");
+        source.push({name: "e"});
+        source.pop();
+        source.pop();
+        source.addText("\n  This is a test of the ");
+        source.push({name: "f"});
+        source.addText("decomposition");
+        source.pop();
+        source.addText(" system.   ");
+        source.push({name: "g"});
+        source.addText("\n");
+        source.pop();
+        source.pop();
+        source.pop();
+
+        test.ok(source.root.children);
+        test.equal(source.root.children.length, 1);
+
+        test.equal(source.getString(), "<c0><c1>  \t </c1><c2>\n<c3>\n<c4></c4></c3>\n  This is a test of the <c5>decomposition</c5> system.   <c6>\n</c6></c2></c0>");
+        test.equal(source.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
+
+        var prefix = source.getPrefix();
+        test.ok(prefix);
+        test.equal(prefix.length, 12);
+        test.deepEqual(prefix[0], {name: "a", use: "start"});
+        test.deepEqual(prefix[1], {name: "b", use: "start"});
+        test.equals(prefix[2], "  \t ");
+        test.deepEqual(prefix[3], {name: "b", use: "end"});
+        test.deepEqual(prefix[4], {name: "c", use: "start"});
+        test.equals(prefix[5], "\n");
+        test.deepEqual(prefix[6], {name: "d", use: "start"});
+        test.equals(prefix[7], "\n");
+        test.deepEqual(prefix[8], {name: "e", use: "start"});
+        test.deepEqual(prefix[9], {name: "e", use: "end"});
+        test.deepEqual(prefix[10], {name: "d", use: "end"});
+        test.equals(prefix[11], "\n  ");
+
+        test.done();
+    },
+
+    testMessageAccumulatorMinimizeVeryComplexSuffix: function(test) {
+        test.expect(4);
+
+        let source = new MessageAccumulator();
+        test.ok(source);
+
+        source.push({name: "a"});
+        source.push({name: "b"});
+        source.addText("  \t ");
+        source.pop();
+        source.push({name: "c"});
+        source.addText("\n");
+        source.push({name: "d"});
+        source.addText("\n");
+        source.push({name: "e"});
+        source.pop();
+        source.pop();
+        source.addText("\n  This is a test of the ");
+        source.push({name: "f"});
+        source.addText("decomposition");
+        source.pop();
+        source.addText(" system.   ");
+        source.push({name: "g"});
+        source.addText("\n");
+        source.pop();
+        source.pop();
+        source.pop();
+
+        test.ok(source.root.children);
+        test.equal(source.root.children.length, 1);
+
+        test.equal(source.getString(), "<c0><c1>  \t </c1><c2>\n<c3>\n<c4></c4></c3>\n  This is a test of the <c5>decomposition</c5> system.   <c6>\n</c6></c2></c0>");
+        test.equal(source.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
+
+        var prefix = source.getSuffix();
+        test.ok(prefix);
+        test.equal(prefix.length, 6);
+
+        test.equals(prefix[0], "   ");
+        test.deepEqual(prefix[1], {name: "g", use: "start"});
+        test.equals(prefix[2], "\n");
+        test.deepEqual(prefix[3], {name: "g", use: "end"});
+        test.deepEqual(prefix[4], {name: "c", use: "end"});
+        test.deepEqual(prefix[5], {name: "a", use: "end"});
+
+        test.done();
+    },
+
+    testMessageAccumulatorMinimizeMappingStillCorrect: function(test) {
+        test.expect(7);
+
+        let ma = MessageAccumulator.create("<c0>This is a test of the <c1>decomposition</c1> system.<c2></c2></c0>");
+        test.ok(ma);
+        let source = new MessageAccumulator();
+        test.ok(source);
+
+        source.push({name: "a"});
+        source.addText("This is a test of the ");
+        source.push({name: "b"});
+        source.addText("decomposition");
+        source.pop();
+        source.addText(" system.");
+        source.push({name: "c"});
+        source.pop();
+        source.pop();
+
+        test.ok(source.root.children);
+        test.equal(source.root.children.length, 1);
+
+        test.deepEqual(source.getMapping(), {
+            "c0": {name: "a"},
+            "c1": {name: "b"},
+            "c2": {name: "c"}
+        });
+
+        test.equal(source.getMinimalString(), "This is a test of the <c0>decomposition</c0> system.");
+
+        test.deepEqual(source.getMapping(), {
+            "c0": {name: "b"}
+        });
 
         test.done();
     }

--- a/test/testmessageacc.js
+++ b/test/testmessageacc.js
@@ -1354,7 +1354,7 @@ module.exports.testAccumulator = {
     },
 
     testMessageAccumulatorMinimizeVeryComplexPrefix: function(test) {
-        test.expect(19);
+        test.expect(18);
 
         let source = new MessageAccumulator();
         test.ok(source);
@@ -1389,7 +1389,7 @@ module.exports.testAccumulator = {
 
         var prefix = source.getPrefix();
         test.ok(prefix);
-        test.equal(prefix.length, 12);
+        test.equal(prefix.length, 11);
         test.deepEqual(prefix[0], {name: "a", use: "start"});
         test.deepEqual(prefix[1], {name: "b", use: "start"});
         test.equals(prefix[2], "  \t ");
@@ -1398,10 +1398,9 @@ module.exports.testAccumulator = {
         test.equals(prefix[5], "\n");
         test.deepEqual(prefix[6], {name: "d", use: "start"});
         test.equals(prefix[7], "\n");
-        test.deepEqual(prefix[8], {name: "e", use: "start"});
-        test.deepEqual(prefix[9], {name: "e", use: "end"});
-        test.deepEqual(prefix[10], {name: "d", use: "end"});
-        test.equals(prefix[11], "\n  ");
+        test.deepEqual(prefix[8], {name: "e", use: "startend"});
+        test.deepEqual(prefix[9], {name: "d", use: "end"});
+        test.equals(prefix[10], "\n  ");
 
         test.done();
     },
@@ -1488,5 +1487,31 @@ module.exports.testAccumulator = {
         });
 
         test.done();
-    }
+    },
+
+    /*
+    testMessageAccumulatorParseSelfClosingComponent: function(test) {
+        test.expect(5);
+
+        let ma = MessageAccumulator.create("This is a test of the <c0/> decomposition system.");
+        test.ok(ma);
+
+        test.ok(ma.root.children);
+        test.equal(ma.root.children.length, 3);
+
+        test.contains(ma.root, {
+            children: [
+                {value: "This is a test of the "},
+                {
+                    children: [],
+                    index: 0
+                },
+                {value: " decomposition system."}
+            ]
+        });
+
+        test.done();
+    },
+    */
+
 };

--- a/test/testmessageacc.js
+++ b/test/testmessageacc.js
@@ -882,7 +882,7 @@ module.exports.testAccumulator = {
     },
 
     testMessageAccumulatorCullOuterComponent: function(test) {
-        test.expect(7);
+        test.expect(3);
 
         let source = new MessageAccumulator();
         test.ok(source);
@@ -901,10 +901,12 @@ module.exports.testAccumulator = {
 
         test.equal(source.getString(), "<c0>You give <c1>the ball</c1> a big <c2>kick</c2> towards the goal.</c0>");
         test.equal(source.getCulledString(), "You give <c1>the ball</c1> a big <c2>kick</c2> towards the goal.");
+
+        test.done();
     },
 
     testMessageAccumulatorCullOuterComponents: function(test) {
-        test.expect(7);
+        test.expect(3);
 
         let source = new MessageAccumulator();
         test.ok(source);
@@ -927,10 +929,12 @@ module.exports.testAccumulator = {
 
         test.equal(source.getString(), "<c0><c1><c2>You give <c3>the ball</c3> a big <c4>kick</c4> towards the goal.</c2></c1></c0>");
         test.equal(source.getCulledString(), "You give <c3>the ball</c3> a big <c4>kick</c4> towards the goal.");
+
+        test.done();
     },
 
     testMessageAccumulatorDontCullNonOuterComponents: function(test) {
-        test.expect(7);
+        test.expect(3);
 
         let source = new MessageAccumulator();
         test.ok(source);
@@ -950,6 +954,48 @@ module.exports.testAccumulator = {
 
         test.equal(source.getString(), "<c0>You give <c1>the ball</c1> a big <c2>kick</c2> towards the goal.</c0> After you score, you celebrate.");
         test.equal(source.getCulledString(), "<c0>You give <c1>the ball</c1> a big <c2>kick</c2> towards the goal.</c0> After you score, you celebrate.");
+
+        test.done();
     },
 
+    testMessageAccumulatorCullEmpty: function(test) {
+        test.expect(3);
+
+        let source = new MessageAccumulator();
+        test.ok(source);
+
+        test.equal(source.getString(), "");
+        test.equal(source.getCulledString(), "");
+
+        test.done();
+    },
+
+    testMessageAccumulatorCullSimple: function(test) {
+        test.expect(3);
+
+        let source = new MessageAccumulator();
+        test.ok(source);
+
+        source.addText("Test");
+
+        test.equal(source.getString(), "Test");
+        test.equal(source.getCulledString(), "Test");
+
+        test.done();
+    },
+
+    testMessageAccumulatorCullUnbalanced: function(test) {
+        test.expect(3);
+
+        let source = new MessageAccumulator();
+        test.ok(source);
+
+        source.push({name: "i"});
+        source.addText("Test");
+
+        test.equal(source.getString(), "<c0>Test</c0>");
+        test.equal(source.getCulledString(), "Test");
+
+        test.done();
+    }
 };

--- a/test/testmessageacc.js
+++ b/test/testmessageacc.js
@@ -990,7 +990,7 @@ module.exports.testAccumulator = {
     },
 
     testMessageAccumulatorGetPrefixMultiple: function(test) {
-        test.expect(3);
+        test.expect(8);
 
         let source = new MessageAccumulator();
         test.ok(source);
@@ -1025,7 +1025,7 @@ module.exports.testAccumulator = {
     },
 
     testMessageAccumulatorGetSuffixMultiple: function(test) {
-        test.expect(3);
+        test.expect(8);
 
         let source = new MessageAccumulator();
         test.ok(source);
@@ -1052,9 +1052,9 @@ module.exports.testAccumulator = {
         var suffix = source.getSuffix();
         test.ok(suffix);
         test.equal(suffix.length, 3);
-        test.deepEqual(suffix[0], {name: "a", use: "end"});
+        test.deepEqual(suffix[0], {name: "y", use: "end"});
         test.deepEqual(suffix[1], {name: "x", use: "end"});
-        test.deepEqual(suffix[2], {name: "y", use: "end"});
+        test.deepEqual(suffix[2], {name: "a", use: "end"});
 
         test.done();
     },
@@ -1085,7 +1085,7 @@ module.exports.testAccumulator = {
     },
 
     testMessageAccumulatorDontMinimizeNonOuterComponentsNoPrefixOrSuffix: function(test) {
-        test.expect(3);
+        test.expect(7);
 
         let source = new MessageAccumulator();
         test.ok(source);


### PR DESCRIPTION
This avoids returning the string with unnecessary components.

- components that surround the entire text: `<c0>text</c0>`
- components that precede or follow the text but don't have any localizable text in them: `<c0>   </c0>text`
- whitespace at the beginning or ending of text is split into a separate text node that is not localizable: `'  text    '` ->  `'  '` + `'text'` + `'    '`
- the parts before and after the localizable text are available so that they can be returned into the document untranslated
- added support for self-closing tags so that we can represent `img` or `p` tags more easily and translators cannot take apart the open and close tags and put something between them: `'The Thai character that looks like this <c0/> is composed of a base character, a vowel character, and a tone mark character.'`