### PR TITLE
Feature: add the ability to keep nodes from being optimized out in getMinimalString

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "message-accumulator",
-    "version": "2.1.1",
+    "version": "2.2.0",
     "main": "./message-accumulator-es5.js",
     "main-es6": "./message-accumulator.js",
     "description": "A package to accumulate localizable snippets of HTML or JSX text and to compose and decompose them to/from localizable strings",

--- a/test/testmessageacc.js
+++ b/test/testmessageacc.js
@@ -1393,6 +1393,31 @@ module.exports.testAccumulator = {
         test.done();
     },
 
+    testMessageAccumulatorMinimizeOuterComponentSelfClosingWithKeepProperty: function(test) {
+        test.expect(3);
+
+        let source = new MessageAccumulator();
+        test.ok(source);
+
+        source.push({name: "a"}, true); // true keeps this component during getMinimalString
+        source.pop();
+        source.addText("You give ");
+        source.push({name: "b"});
+        source.addText("the ball");
+        source.pop();
+        source.addText(" a big ");
+        source.push({name: "i"});
+        source.addText("kick");
+        source.pop();
+        source.addText(" towards the goal.");
+        source.pop();
+
+        test.equal(source.getString(), "<c0/>You give <c1>the ball</c1> a big <c2>kick</c2> towards the goal.");
+        test.equal(source.getMinimalString(), "<c0/>You give <c1>the ball</c1> a big <c2>kick</c2> towards the goal.");
+
+        test.done();
+    },
+
     testMessageAccumulatorMinimizeOuterComponentsButNotParams: function(test) {
         test.expect(3);
 
@@ -1414,6 +1439,30 @@ module.exports.testAccumulator = {
 
         test.equal(source.getString(), "<c0><p0/>You give <c1>the ball</c1> a big <c2>kick</c2> towards the goal.</c0>");
         test.equal(source.getMinimalString(), "<p0/>You give <c0>the ball</c0> a big <c1>kick</c1> towards the goal.");
+
+        test.done();
+    },
+
+    testMessageAccumulatorMinimizeOuterComponentsButNotWithKeepProperty: function(test) {
+        test.expect(3);
+
+        let source = new MessageAccumulator();
+        test.ok(source);
+
+        source.push({name: "a"}, true); // true to keep this one
+        source.addText("You give ");
+        source.push({name: "b"});
+        source.addText("the ball");
+        source.pop();
+        source.addText(" a big ");
+        source.push({name: "i"});
+        source.addText("kick");
+        source.pop();
+        source.addText(" towards the goal.");
+        source.pop();
+
+        test.equal(source.getString(), "<c0>You give <c1>the ball</c1> a big <c2>kick</c2> towards the goal.</c0>");
+        test.equal(source.getMinimalString(), "<c0>You give <c1>the ball</c1> a big <c2>kick</c2> towards the goal.</c0>");
 
         test.done();
     },


### PR DESCRIPTION
 Now if you pass a boolean "keep" parameter to the push method, then the node will never be optimized out during a call to getMinimalString. Sometimes the caller knows better which things to optimize out and which to leave alone, and this parameter allows the caller to specify.