### PR TITLE
Reversion the last release to v3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,3 +202,27 @@ these new ones.
 Step 4. When all of the text is translated, convert the AST back into text
 again to reconstruct your translated file.
 
+## License
+
+Copyright © 2018-2024, JEDLSoft
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
+# Release Notes
+
+## v3.0.0
+
+- convert all unit tests from nodeunit to jest
+- export the es6 code as real es6 modules and old transpiled javascript
+  for older packages to use (breaking change)

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "prepare": "conditional-install"
     },
     "dependencies": {
-        "ilib-tree-node": "^1.3.1"
+        "ilib-tree-node": "^2.0.0"
     },
     "devDependencies": {
         "@babel/core": "^7.23.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "message-accumulator",
-    "version": "2.2.2",
+    "version": "3.0.0",
     "main": "./lib/message-accumulator.js",
     "module": "./src/message-accumulator.js",
     "exports": {


### PR DESCRIPTION
- the previous release (v2.2.2) had a breaking change, so reversioning it to v3.0.0 so that it doesn't break other things that depend on this when they use carat dependencies
- v2.2.2 is already deprecated in npm and we will publish v2.2.3 (= v2.2.1) to supercede it in the v2.x line